### PR TITLE
framework AMD 7040: Add config option for wake-on-AC fix

### DIFF
--- a/framework/13-inch/7040-amd/default.nix
+++ b/framework/13-inch/7040-amd/default.nix
@@ -1,18 +1,38 @@
-{ lib, pkgs, ... }: {
+{ config, lib, pkgs, ... }:
+
+let
+  cfg = config.hardware.framework.amd-7040;
+in
+{
   imports = [
     ../common
     ../common/amd.nix
   ];
 
-  # Newer kernel is better for amdgpu driver updates
-  # Requires at least 5.16 for working wi-fi and bluetooth (RZ616, kmod mt7922):
-  # https://wireless.wiki.kernel.org/en/users/drivers/mediatek
-  boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") (lib.mkDefault pkgs.linuxPackages_latest);
+  options = {
+    hardware.framework.amd-7040.preventWakeOnAC = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Stop the system waking from suspend when the AC is plugged
+        in. The catch: it also disables waking from the keyboard.
 
-  # Custom udev rules
-  services.udev.extraRules = ''
-    # Prevent wake when plugging in AC during suspend. Trade-off: keyboard wake disabled. See:
-    # https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
-    #ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"
-  '';
+        See:
+        https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
+      '';
+    };
+  };
+
+  config = {
+    # Newer kernel is better for amdgpu driver updates
+    # Requires at least 5.16 for working wi-fi and bluetooth (RZ616, kmod mt7922):
+    # https://wireless.wiki.kernel.org/en/users/drivers/mediatek
+    boot.kernelPackages = lib.mkIf (lib.versionOlder pkgs.linux.version "6.1") (lib.mkDefault pkgs.linuxPackages_latest);
+
+    services.udev.extraRules = lib.optionalString cfg.preventWakeOnAC ''
+      # Prevent wake when plugging in AC during suspend. Trade-off: keyboard wake disabled. See:
+      # https://community.frame.work/t/tracking-framework-amd-ryzen-7040-series-lid-wakeup-behavior-feedback/39128/45
+      ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"
+    '';
+  };
 }


### PR DESCRIPTION
Hopefully you can merge this as a start, and then nixos-hardware maintainers can help you get the option names etc exactly right.

###### Description of changes

Added a config option for the wake-from-AC fix.

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [X] Tested the changes in your own NixOS Configuration
- [X] Tested the changes end-to-end by using your fork of `nixos-hardware` and
      importing it via `<nixos-hardware>` or Flake input

